### PR TITLE
[FIX] Removal of Email Verification Step when first time signin & some minor changes

### DIFF
--- a/src/form/utils/actions.ts
+++ b/src/form/utils/actions.ts
@@ -1,8 +1,6 @@
 // MONGOOSE
 import { ClientSession } from 'mongoose';
 
-import generatePassword from 'generate-password';
-
 // OTHERS
 import { sendEmail } from '../../utils/email';
 import { User } from '../../user/utils/userModel';
@@ -377,9 +375,14 @@ export const runFormActions = async ({ triggerType, response, form, args, sessio
                 Name: 'email',
                 Value: uEmail,
               },
+              // AUTO VERIFY THE EMAIL | THIS WILL BE REMOVED IN THE FUTURE
               {
                 Name: 'email_verified',
-                Value: 'False',
+                Value: 'True',
+              },
+              {
+                Name: 'custom:email_verified',
+                Value: '0',
               },
               {
                 Name: 'name',

--- a/src/permissions/utils/cognitoHandlers.ts
+++ b/src/permissions/utils/cognitoHandlers.ts
@@ -170,6 +170,8 @@ export const createAWSUser = async (payload: ICreateUser) => {
   //   })
   //   .promise();
 
+  // SETS THE TEMPORARY PASSWORD AS USER'S PERMANENT PASSWORD
+  // SO WHEN CREATING USER WITH adminCreateUser() the "FORCE_RESET_PASSWORD" Challenge is removed
   // const res2 = await cisp
   //   .adminSetUserPassword({
   //     Password: payload.TemporaryPassword,

--- a/src/user/trigger.ts
+++ b/src/user/trigger.ts
@@ -6,23 +6,22 @@ import {
 import {
   preSignUpTrigger,
   postAuthenticationTrigger,
-  // postConfirmationTrigger,
+  postConfirmationSignupTrigger,
 } from './utils/cognitoTriggers';
 
 export const handler = async (
   event: PreSignUpTriggerEvent | PostConfirmationTriggerEvent | PostAuthenticationTriggerEvent,
 ): Promise<any> => {
-  if (event.triggerSource && event.triggerSource.includes('PreSignUp_')) {
-    return await preSignUpTrigger(event);
+  if (event.triggerSource) {
+    if (event.triggerSource.includes('PreSignUp_')) {
+      return await preSignUpTrigger(event);
+    } else if (event.triggerSource === 'PostAuthentication_Authentication') {
+      return await postAuthenticationTrigger(event as PostAuthenticationTriggerEvent);
+    }
+    // else if (event.triggerSource === 'PostConfirmation_ConfirmSignUp') {
+    //   return await postConfirmationSignupTrigger(event);
+    // }
   }
-  if (event.triggerSource && event.triggerSource === 'PostAuthentication_Authentication') {
-    return await postAuthenticationTrigger(event);
-  }
-  // if (
-  //   event.triggerSource &&
-  //   event.triggerSource === 'PostConfirmation_ConfirmSignUp'
-  // ) {
-  //   return await postConfirmationTrigger(event);
-  // }
+
   return event;
 };

--- a/src/user/utils/PostAuthenticationTrigger.ts
+++ b/src/user/utils/PostAuthenticationTrigger.ts
@@ -1,0 +1,24 @@
+/* eslint-disable no-prototype-builtins */
+import { PostAuthenticationTriggerEvent } from 'aws-lambda';
+import { updateEmailVerified } from './helper';
+
+export const postAuthenticationTrigger = async (event: PostAuthenticationTriggerEvent) => {
+  const { userAttributes } = event.request;
+  console.log('Post Authentication SignIn Triggered');
+  // if (!event.request.userAttributes.hasOwnProperty('custom:_id')) {
+  //   await DB();
+  //   const userId = event.userName;
+  //   const tempUser: any = await User.findOne({
+  //     userId: userId,
+  //   });
+  //   await adminUpdateUserAttribute(userId, {
+  //     Name: 'custom:_id',
+  //     Value: `${tempUser._id}`,
+  //   });
+  // }
+
+  // if the email is verified then also make emailVerified = true property of User in the Database
+  await updateEmailVerified(event);
+
+  return event;
+};

--- a/src/user/utils/cognitoTriggers.ts
+++ b/src/user/utils/cognitoTriggers.ts
@@ -3,6 +3,7 @@ import {
   PreSignUpTriggerEvent,
   PostConfirmationTriggerEvent,
   PostAuthenticationTriggerEvent,
+  PostConfirmationConfirmSignUpTriggerEvent,
 } from 'aws-lambda';
 import {
   listUsersByEmail,
@@ -124,9 +125,9 @@ export const preSignUpTrigger = async (
   return event;
 };
 
-export const postAuthenticationTrigger = async (
-  event: PreSignUpTriggerEvent | PostConfirmationTriggerEvent | PostAuthenticationTriggerEvent,
-) => {
+export const postAuthenticationTrigger = async (event: PostAuthenticationTriggerEvent) => {
+  const { userAttributes } = event.request;
+  console.log('Post Authentication SignIn Triggered');
   // if (!event.request.userAttributes.hasOwnProperty('custom:_id')) {
   //   await DB();
   //   const userId = event.userName;
@@ -139,9 +140,20 @@ export const postAuthenticationTrigger = async (
   //   });
   // }
 
-  // if the email is verified then also make emailVerified = true property of User in the Database
+  if (!userAttributes['custom:email_verified'] || userAttributes['custom:email_verified'] === '0') {
+    // if the email is verified then also make emailVerified = true property of User in the Database
+    await updateEmailVerified(event);
+  }
 
-  await updateEmailVerified(event.request.userAttributes);
+  return event;
+};
+
+export const postConfirmationSignupTrigger = async (
+  event: PostConfirmationConfirmSignUpTriggerEvent,
+) => {
+  console.log('Post Confirmation Signup Triggered');
+  // if the email is verified in cognito then also make emailVerified = true property of User in the Database
+  // await updateEmailVerified(event);
 
   return event;
 };

--- a/src/user/utils/cognitoTriggers.ts
+++ b/src/user/utils/cognitoTriggers.ts
@@ -15,8 +15,13 @@ import {
   adminConfirmSignUp,
   updateEmailVerified,
 } from './helper';
+
+import { postAuthenticationTrigger } from './PostAuthenticationTrigger';
+
 import { User } from './userModel';
 import { DB } from '../../utils/DB';
+
+export { postAuthenticationTrigger };
 
 export const preSignUpTrigger = async (
   event: PreSignUpTriggerEvent | PostConfirmationTriggerEvent | PostAuthenticationTriggerEvent,
@@ -120,29 +125,6 @@ export const preSignUpTrigger = async (
   if (triggerSource === 'PreSignUp_ExternalProvider') {
     const providerName = userName.split('_')[0].toUpperCase();
     throw new Error(`${providerName}_ACCOUNT_LINKED`);
-  }
-
-  return event;
-};
-
-export const postAuthenticationTrigger = async (event: PostAuthenticationTriggerEvent) => {
-  const { userAttributes } = event.request;
-  console.log('Post Authentication SignIn Triggered');
-  // if (!event.request.userAttributes.hasOwnProperty('custom:_id')) {
-  //   await DB();
-  //   const userId = event.userName;
-  //   const tempUser: any = await User.findOne({
-  //     userId: userId,
-  //   });
-  //   await adminUpdateUserAttribute(userId, {
-  //     Name: 'custom:_id',
-  //     Value: `${tempUser._id}`,
-  //   });
-  // }
-
-  if (!userAttributes['custom:email_verified'] || userAttributes['custom:email_verified'] === '0') {
-    // if the email is verified then also make emailVerified = true property of User in the Database
-    await updateEmailVerified(event);
   }
 
   return event;

--- a/src/user/utils/helper.ts
+++ b/src/user/utils/helper.ts
@@ -173,20 +173,20 @@ export const adminConfirmSignUp = (username = '') => {
 export const updateEmailVerified = async (event: PostAuthenticationTriggerEvent) => {
   const { userAttributes } = event.request;
 
-  if (!userAttributes['custom:email_verified'] || userAttributes['custom:email_verified'] === '0') {
-    await cognitoIdp
-      .adminUpdateUserAttributes({
-        UserAttributes: [
-          {
-            Name: 'custom:email_verified',
-            Value: '1',
-          },
-        ],
-        UserPoolId: event.userPoolId,
-        Username: userAttributes.email,
-      })
-      .promise();
-  }
+  // if (!userAttributes['custom:email_verified'] || userAttributes['custom:email_verified'] === '0') {
+  //   await cognitoIdp
+  //     .adminUpdateUserAttributes({
+  //       UserAttributes: [
+  //         {
+  //           Name: 'custom:email_verified',
+  //           Value: '1',
+  //         },
+  //       ],
+  //       UserPoolId: event.userPoolId,
+  //       Username: userAttributes.email,
+  //     })
+  //     .promise();
+  // }
 
   await DB();
   const userForm = await FormModel.findOne({
@@ -198,8 +198,7 @@ export const updateEmailVerified = async (event: PostAuthenticationTriggerEvent)
   }
 
   const userResponseId = userAttributes['custom:_id'];
-  const isEmailVerifiedinCongito =
-    userAttributes['email_verified'] === 'True' || userAttributes['email_verified'] === 'true';
+  const isEmailVerifiedinCongito = userAttributes['cognito:user_status'] === 'CONFIRMED';
 
   const emailVerifiedFieldId = userForm.fields
     .find((val) => val.label === UserFormConfig.fields.emailVerified)
@@ -223,9 +222,27 @@ export const updateEmailVerified = async (event: PostAuthenticationTriggerEvent)
     (value) => value.field === emailVerifiedFieldId,
   );
 
+  const defaultResponseValue = {
+    field: '',
+    value: '',
+    valueNumber: null,
+    valueBoolean: null,
+    valueDate: null,
+    media: [],
+    values: [],
+    template: null,
+    page: null,
+    form: null,
+    response: null,
+    options: { option: false },
+    tempMedia: [],
+    tempMediaFiles: [],
+  };
+
   if (!EmailVerifiedField) {
     // Email Verified Field is not present. so create the field and push it in values array
     const newResponseValue: Partial<ResponseValueType> = {
+      ...defaultResponseValue,
       field: emailVerifiedFieldId,
       valueBoolean: isEmailVerifiedinCongito,
     };


### PR DESCRIPTION
This commit introduces 2 changes :
- Removed the Email Verification step when user signin for the first time by using the Status Attribute of User's Entry in AWS Cognito

- Fixed a bug where not all default properties were being added in the user's response database when adding the email field's value in the database